### PR TITLE
chore: Configure CI to run on both main and develop branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,15 @@ name: Cypress CI
 
 # This section defines when the workflow will run.
 on:
-  # The workflow is triggered on every push to the 'main' branch.
+  # The workflow is triggered on every push and pull_request to the 'main' and 'develop' branch.
   push:
     branches:
       - main
-  
+      - develop
+  pull_request: 
+    branches:
+        - main
+        - develop
   # The workflow is also triggered on a schedule (e.g., every day at 12:00 AM UTC).
   # This is useful for nightly runs to ensure everything is working even if there are no code changes.
   schedule:


### PR DESCRIPTION
This commit modifies the CI workflow file to trigger on both 'main' and 'develop' branches. This change supports a GitFlow-like strategy where 'develop' is the primary branch for new feature integration, and 'main' is reserved for production releases. The workflow will now automatically run tests for all pushes and pull requests to both branches.